### PR TITLE
Store aggregate in database instead of individual events

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ Note: Common user directories like `Documents`, `Downloads`, `Pictures`, `Videos
    ```
 
 ## Database
-The database contains an `interactions` table with the following data.
+The database contains an `files` table with the following data:
 
-| **Name**   | **Column** | **Description**                                          |
-|------------|------------|----------------------------------------------------------|
-| **Id**     | `id`       | Identifies a specific interaction                        |
-| **Time**   | multiple   | When the file or directory was created                   |
-| **File**   | `file`     | The location of the newly created file or directory      |
-| **Source** | `source`   | The path of the program responsible for the creation     |
+| **Name**         | **Column**      | **Description**                                                             |
+|------------------|-----------------|-----------------------------------------------------------------------------|
+| **File**         | `file` 🔑       | The location of the newly created file or directory                         |
+| **Executable**   | `executable` 🔑 | The path of the program responsible for the creation                        |
+| **Time added**   | `added_at`      | When the file - executable entry was first added                            |
+| **Time changed** | `changed_at`    | When the file - executable entry was last changed                           |
+| **Total count**  | `count`         | The total amount of times the executable was detected modifying to the file |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Note: Common user directories like `Documents`, `Downloads`, `Pictures`, `Videos
 ## Database
 The database contains an `files` table with the following data:
 
-| **Name**         | **Column**      | **Description**                                                             |
-|------------------|-----------------|-----------------------------------------------------------------------------|
-| **File**         | `file` 🔑       | The location of the newly created file or directory                         |
-| **Executable**   | `executable` 🔑 | The path of the program responsible for the creation                        |
-| **Time added**   | `added_at`      | When the file - executable entry was first added                            |
-| **Time changed** | `changed_at`    | When the file - executable entry was last changed                           |
-| **Total count**  | `count`         | The total amount of times the executable was detected modifying to the file |
+| **Name**         | **Column**      | **Description**                                                          |
+|------------------|-----------------|--------------------------------------------------------------------------|
+| **File**         | `file` 🔑       | The location of the modified file or directory                           |
+| **Executable**   | `executable` 🔑 | The path of the program responsible for modifying the file               |
+| **Time added**   | `added_at`      | When the file - executable entry was first added                         |
+| **Time changed** | `changed_at`    | When the file - executable entry was last changed                        |
+| **Total count**  | `count`         | The total amount of times the executable was detected modifying the file |
 
 ## Contributing
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,8 +1,3 @@
-/*
-SELECT year, month, day, hour, minute, second FROM interactions
-ORDER BY year DESC, month DESC, day DESC, hour DESC, minute DESC, second DESC
-LIMIT 1
- */
 use rusqlite::Connection;
 use crate::ausearch_parse::Interaction;
 use crate::time::{Date, DateTime, Time};
@@ -10,49 +5,36 @@ use crate::time::{Date, DateTime, Time};
 pub fn open_db(path: &str) -> Connection {
     let conn = Connection::open(path).expect("Failed to open database");
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS interactions (
-            id          INTEGER PRIMARY KEY,
-            year        INTEGER NOT NULL,
-            month       INTEGER NOT NULL,
-            day         INTEGER NOT NULL,
-            hour        INTEGER NOT NULL,
-            minute      INTEGER NOT NULL,
-            second      INTEGER NOT NULL,
+        "CREATE TABLE IF NOT EXISTS files (
             file        TEXT NOT NULL,
-            source      TEXT NOT NULL
+            executable  TEXT NOT NULL,
+            added_at    INTEGER NOT NULL,
+            changed_at  INTEGER NOT NULL,
+            count       INTEGER NOT NULL,
+            PRIMARY KEY (file, executable)
         )",
         (),
-    ).expect("Failed to create table");
+    ).expect("Failed to create files table");
     return conn;
 }
 
-pub fn insert_interaction(conn: &Connection, interaction: &Interaction) {
+pub fn add_entry(conn: &Connection, file_path: &str, executable: &str, datetime: &DateTime) {
     conn.execute("
-        INSERT INTO interactions (year, month, day, hour, minute, second, file, source)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-    ", (&interaction.date().year(), &interaction.date().month(), &interaction.date().day(), &interaction.time().hour(), &interaction.time().minute(), &interaction.time().second(), &interaction.file(), &interaction.source()),
+        INSERT OR REPLACE INTO files
+        (file, executable, added_at, changed_at, count)
+        VALUES (?1, ?2, ?3, ?3, 1)
+        ON CONFLICT (file, executable) DO UPDATE SET
+             changed_at = ?3,
+             count = count + 1;
+    ", (file_path, executable, datetime.as_integer()),
     ).expect("Failed to insert interaction into database");
 }
 
-pub fn query_latest_interaction_time(connection: &Connection) -> Result<Option<DateTime>, String> {
-    let mut stmt = connection.prepare("
-        SELECT year, month, day, hour, minute, second FROM interactions
-        ORDER BY year DESC, month DESC, day DESC, hour DESC, minute DESC, second DESC
-        LIMIT 1
-    ").map_err(|_| "Failed to prepare query".to_string())?;
+pub fn query_latest_time(conn: &Connection) -> Result<Option<DateTime>, String> {
+    let mut stmt = conn.prepare("SELECT MAX(changed_at) as latest FROM files").map_err(|_| "Failed to prepare query".to_string())?;
     let mut rows = stmt.query([]).map_err(|_| "Failed to execute query")?;
     let row = rows.next().map_err(|_| "Failed to get row")?.unwrap();
-    let date = DateTime {
-        date: Date::from_ymd(
-            row.get(0).map_err(|_| "Failed to get year".to_string())?,
-            row.get(1).map_err(|_| "Failed to get month".to_string())?,
-            row.get(2).map_err(|_| "Failed to get day".to_string())?
-        ),
-        time: Time::from_hms(
-            row.get(3).map_err(|_| "Failed to get hour".to_string())?,
-            row.get(4).map_err(|_| "Failed to get minute".to_string())?,
-            row.get(5).map_err(|_| "Failed to get second".to_string())?,
-        )
-    };
-    return Ok(Some(date));
+    let datetime_int: Option<usize> = row.get(0).map_err(|_| "Failed to get column".to_string())?;
+    let datetime = datetime_int.map(|int| DateTime::from_integer(int));
+    Ok(datetime)
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -63,3 +63,50 @@ pub struct DateTime {
     pub date: Date,
     pub time: Time,
 }
+impl DateTime {
+    pub fn as_integer(&self) -> usize {
+        (((((self.date.year * 100) + self.date.month) * 100 + self.date.day) * 100 + self.time.hour) * 100 + self.time.minute) * 100 + self.time.second
+    }
+    pub fn from_integer(integer: usize) -> DateTime {
+        let mut tmp = integer;
+        let seconds = tmp % 100;
+        tmp /= 100;
+        let minutes = tmp % 100;
+        tmp /= 100;
+        let hours = tmp % 100;
+        let time = Time::from_hms(hours, minutes, seconds);
+        tmp /= 100;
+        let days = tmp % 100;
+        tmp /= 100;
+        let months = tmp % 100;
+        tmp /= 100;
+        let years = tmp;
+        let date = Date::from_ymd(years, months, days);
+        DateTime { date, time }
+    }
+    pub fn to_string(&self) -> String { format!("{:02}-{:02}-{:02} {:02}:{:02}:{:02}", self.date.year, self.date.month, self.date.day, self.time.hour, self.time.minute, self.time.second) }
+}
+
+#[test]
+fn test_datetime_conversion() {
+    for year in (2000..=2020).step_by(5) {
+        for month in (1..=12).step_by(3) {
+            for day in 1..=28 {
+                for hour in 0..=23 {
+                    for minute in (0..=59).step_by(15) {
+                        for second in (0..=59).step_by(15) {
+                            let time = Time::from_hms(hour, minute, second);
+                            let date = Date::from_ymd(year, month, day);
+                            let dt = DateTime { date, time };
+                            let as_int = dt.as_integer();
+                            let dt2 = DateTime::from_integer(as_int);
+                            let dt_s = dt.to_string();
+                            let dt2_s = dt2.to_string();
+                            assert_eq!(dt_s, dt2_s);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
When testing it myself, the database quickly grew to thousands of rows. I added exclusions to solve this but realized this is not the best solution because it requires manually adding exclusions for many executables / directories. By only storing one row for each pair of files and executables with some aggregate information (time added, time changed, total count) all required information is stored with a minimal amount of data. 